### PR TITLE
Fix null slice processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
+target
 /build
 /generated

--- a/crates/arkworks/Cargo.lock
+++ b/crates/arkworks/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-scale",
  "build-helper",
+ "cpp",
 ]
 
 [[package]]
@@ -317,6 +318,10 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "cpp"
+version = "0.0.1"
 
 [[package]]
 name = "crossbeam-deque"

--- a/crates/arkworks/Cargo.toml
+++ b/crates/arkworks/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
+cpp = { path = "../cpp" }
 ark-ec = { version = "0.4.2", default-features = false }
 ark-bls12-377 = { version = "0.4.0", features = ["curve"], default-features = false }
 ark-bls12-381 = { version = "0.4.0", features = ["curve"], default-features = false }

--- a/crates/arkworks/build.rs
+++ b/crates/arkworks/build.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     build_helper::run_cbindgen();
 }

--- a/crates/arkworks/src/lib.rs
+++ b/crates/arkworks/src/lib.rs
@@ -58,13 +58,7 @@ impl From<std::result::Result<Vec<u8>, ()>> for Result {
 
 impl BytesVec {
     unsafe fn as_slice(&self) -> Vec<u8> {
-        // Calling code may pass a null pointer for empty slices, but Rust expects an aligned pointer
-        let aligned_data = if self.data == core::ptr::null_mut() {
-            core::ptr::NonNull::<u8>::dangling().as_ptr()
-        } else {
-            self.data
-        };
-        std::slice::from_raw_parts_mut(aligned_data, self.size as usize).to_vec()
+        cpp::from_raw_parts_mut(self.data, self.size as usize).to_vec()
     }
 }
 

--- a/crates/arkworks/src/utils.rs
+++ b/crates/arkworks/src/utils.rs
@@ -18,109 +18,103 @@
 //! Generic executions of the operations for *Arkworks* elliptic curves.
 
 use ark_ec::{
-	pairing::{MillerLoopOutput, Pairing, PairingOutput},
-	short_weierstrass,
-	short_weierstrass::SWCurveConfig,
-	twisted_edwards,
-	twisted_edwards::TECurveConfig,
-	CurveConfig, VariableBaseMSM,
+    pairing::{MillerLoopOutput, Pairing, PairingOutput},
+    short_weierstrass,
+    short_weierstrass::SWCurveConfig,
+    twisted_edwards,
+    twisted_edwards::TECurveConfig,
+    CurveConfig, VariableBaseMSM,
 };
 use ark_scale::{
-	hazmat::ArkScaleProjective,
-	scale::{Decode, Encode},
+    hazmat::ArkScaleProjective,
+    scale::{Decode, Encode},
 };
 use std::vec::Vec;
 
 // Scale codec type which is expected to be used by the host functions.
 //
 // Encoding is set to `HOST_CALL` which is a shortcut for "not-validated" and "not-compressed".
-type ArkScale<T> = ark_scale::ArkScale<T, {  ark_scale::HOST_CALL }>;
+type ArkScale<T> = ark_scale::ArkScale<T, { ark_scale::HOST_CALL }>;
 // type Input<'a> = &'a mut [u8];
 type Input<'a> = Vec<u8>;
 pub fn multi_miller_loop<Curve: Pairing>(g1: Input, g2: Input) -> Result<Vec<u8>, ()> {
-	let g1 = <ArkScale<Vec<<Curve as Pairing>::G1Affine>> as Decode>::decode(&mut g1.as_slice())
-		.map_err(|_| ())?;
-	let g2 = <ArkScale<Vec<<Curve as Pairing>::G2Affine>> as Decode>::decode(&mut g2.as_slice())
-		.map_err(|_| ())?;
+    let g1 = <ArkScale<Vec<<Curve as Pairing>::G1Affine>> as Decode>::decode(&mut g1.as_slice())
+        .map_err(|_| ())?;
+    let g2 = <ArkScale<Vec<<Curve as Pairing>::G2Affine>> as Decode>::decode(&mut g2.as_slice())
+        .map_err(|_| ())?;
 
-	let result = Curve::multi_miller_loop(g1.0, g2.0).0;
+    let result = Curve::multi_miller_loop(g1.0, g2.0).0;
 
-	let result: ArkScale<<Curve as Pairing>::TargetField> = result.into();
-	Ok(result.encode())
+    let result: ArkScale<<Curve as Pairing>::TargetField> = result.into();
+    Ok(result.encode())
 }
 
 pub fn final_exponentiation<Curve: Pairing>(target: Input) -> Result<Vec<u8>, ()> {
-	let target =
-		<ArkScale<<Curve as Pairing>::TargetField> as Decode>::decode(&mut target.as_slice())
-			.map_err(|_| ())?;
+    let target =
+        <ArkScale<<Curve as Pairing>::TargetField> as Decode>::decode(&mut target.as_slice())
+            .map_err(|_| ())?;
 
-	let result = Curve::final_exponentiation(MillerLoopOutput(target.0)).ok_or(())?;
+    let result = Curve::final_exponentiation(MillerLoopOutput(target.0)).ok_or(())?;
 
-	let result: ArkScale<PairingOutput<Curve>> = result.into();
-	Ok(result.encode())
+    let result: ArkScale<PairingOutput<Curve>> = result.into();
+    Ok(result.encode())
 }
 
-pub fn msm_sw<Curve: SWCurveConfig>(bases:Input , scalars:Input) -> Result<Vec<u8>, ()> {
-	let bases =
-		<ArkScale<Vec<short_weierstrass::Affine<Curve>>> as Decode>::decode(&mut bases.as_slice())
-			.map_err(|_| ())?;
-	let scalars = <ArkScale<Vec<<Curve as CurveConfig>::ScalarField>> as Decode>::decode(&mut 
-		scalars.as_slice()
-	)
-	.map_err(|_| ())?;
+pub fn msm_sw<Curve: SWCurveConfig>(bases: Input, scalars: Input) -> Result<Vec<u8>, ()> {
+    let bases =
+        <ArkScale<Vec<short_weierstrass::Affine<Curve>>> as Decode>::decode(&mut bases.as_slice())
+            .map_err(|_| ())?;
+    let scalars = <ArkScale<Vec<<Curve as CurveConfig>::ScalarField>> as Decode>::decode(
+        &mut scalars.as_slice(),
+    )
+    .map_err(|_| ())?;
 
-	let result =
-		<short_weierstrass::Projective<Curve> as VariableBaseMSM>::msm(&bases.0, &scalars.0)
-			.map_err(|_| ())?;
+    let result =
+        <short_weierstrass::Projective<Curve> as VariableBaseMSM>::msm(&bases.0, &scalars.0)
+            .map_err(|_| ())?;
 
-	let result: ArkScaleProjective<short_weierstrass::Projective<Curve>> = result.into();
-	Ok(result.encode())
+    let result: ArkScaleProjective<short_weierstrass::Projective<Curve>> = result.into();
+    Ok(result.encode())
 }
 
 pub fn msm_te<Curve: TECurveConfig>(bases: Input, scalars: Input) -> Result<Vec<u8>, ()> {
-	let bases =
-		<ArkScale<Vec<twisted_edwards::Affine<Curve>>> as Decode>::decode(&mut bases.as_slice())
-			.map_err(|_| ())?;
-	let scalars = <ArkScale<Vec<<Curve as CurveConfig>::ScalarField>> as Decode>::decode(&mut 
-		scalars.as_slice()
-	)
-	.map_err(|_| ())?;
+    let bases =
+        <ArkScale<Vec<twisted_edwards::Affine<Curve>>> as Decode>::decode(&mut bases.as_slice())
+            .map_err(|_| ())?;
+    let scalars = <ArkScale<Vec<<Curve as CurveConfig>::ScalarField>> as Decode>::decode(
+        &mut scalars.as_slice(),
+    )
+    .map_err(|_| ())?;
 
-	let result = <twisted_edwards::Projective<Curve> as VariableBaseMSM>::msm(&bases.0, &scalars.0)
-		.map_err(|_| ())?;
+    let result = <twisted_edwards::Projective<Curve> as VariableBaseMSM>::msm(&bases.0, &scalars.0)
+        .map_err(|_| ())?;
 
-	let result: ArkScaleProjective<twisted_edwards::Projective<Curve>> = result.into();
-	Ok(result.encode())
+    let result: ArkScaleProjective<twisted_edwards::Projective<Curve>> = result.into();
+    Ok(result.encode())
 }
 
-pub fn mul_projective_sw<Group: SWCurveConfig>(
-	base: Input,
-	scalar: Input,
-) -> Result<Vec<u8>, ()> {
-	let base = <ArkScaleProjective<short_weierstrass::Projective<Group>> as Decode>::decode(&mut 
-		base.as_slice()
-	)
-	.map_err(|_| ())?;
-	let scalar = <ArkScale<Vec<u64>> as Decode>::decode(&mut scalar.as_slice()).map_err(|_| ())?;
+pub fn mul_projective_sw<Group: SWCurveConfig>(base: Input, scalar: Input) -> Result<Vec<u8>, ()> {
+    let base = <ArkScaleProjective<short_weierstrass::Projective<Group>> as Decode>::decode(
+        &mut base.as_slice(),
+    )
+    .map_err(|_| ())?;
+    let scalar = <ArkScale<Vec<u64>> as Decode>::decode(&mut scalar.as_slice()).map_err(|_| ())?;
 
-	let result = <Group as SWCurveConfig>::mul_projective(&base.0, &scalar.0);
+    let result = <Group as SWCurveConfig>::mul_projective(&base.0, &scalar.0);
 
-	let result: ArkScaleProjective<short_weierstrass::Projective<Group>> = result.into();
-	Ok(result.encode())
+    let result: ArkScaleProjective<short_weierstrass::Projective<Group>> = result.into();
+    Ok(result.encode())
 }
 
-pub fn mul_projective_te<Group: TECurveConfig>(
-	base: Input,
-	scalar: Input,
-) -> Result<Vec<u8>, ()> {
-	let base = <ArkScaleProjective<twisted_edwards::Projective<Group>> as Decode>::decode(&mut 
-		base.as_slice()
-	)
-	.map_err(|_| ())?;
-	let scalar = <ArkScale<Vec<u64>> as Decode>::decode(&mut scalar.as_slice()).map_err(|_| ())?;
+pub fn mul_projective_te<Group: TECurveConfig>(base: Input, scalar: Input) -> Result<Vec<u8>, ()> {
+    let base = <ArkScaleProjective<twisted_edwards::Projective<Group>> as Decode>::decode(
+        &mut base.as_slice(),
+    )
+    .map_err(|_| ())?;
+    let scalar = <ArkScale<Vec<u64>> as Decode>::decode(&mut scalar.as_slice()).map_err(|_| ())?;
 
-	let result = <Group as TECurveConfig>::mul_projective(&base.0, &scalar.0);
+    let result = <Group as TECurveConfig>::mul_projective(&base.0, &scalar.0);
 
-	let result: ArkScaleProjective<twisted_edwards::Projective<Group>> = result.into();
-	Ok(result.encode())
+    let result: ArkScaleProjective<twisted_edwards::Projective<Group>> = result.into();
+    Ok(result.encode())
 }

--- a/crates/bandersnatch_vrfs/Cargo.lock
+++ b/crates/bandersnatch_vrfs/Cargo.lock
@@ -386,6 +386,7 @@ version = "0.4.0"
 dependencies = [
  "bandersnatch_vrfs",
  "build-helper",
+ "cpp",
  "parity-scale-codec",
  "serde",
 ]
@@ -521,6 +522,10 @@ dependencies = [
  "merlin",
  "rand_chacha",
 ]
+
+[[package]]
+name = "cpp"
+version = "0.0.1"
 
 [[package]]
 name = "cpufeatures"
@@ -1380,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -1400,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1410,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -1420,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -1439,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "Inflector",
  "expander",
@@ -1452,12 +1457,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -1469,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -1480,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d0d8e29197a783f3ea300569afc50244a280cafa"
+source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
 dependencies = [
  "impl-trait-for-tuples",
  "log",

--- a/crates/bandersnatch_vrfs/Cargo.toml
+++ b/crates/bandersnatch_vrfs/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
+cpp = { path = "../cpp" }
 bandersnatch_vrfs = { git = "https://github.com/w3f/ring-vrf", rev = "4831a70", default-features = false, features = ["substrate-curves"], optional = true }
 serde = "1.0.193"
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/crates/cpp/Cargo.toml
+++ b/crates/cpp/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "cpp"
+version = "0.0.1"
+edition = "2021"

--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -1,0 +1,17 @@
+pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
+    let data = if data.is_null() {
+        core::ptr::NonNull::dangling().as_ptr()
+    } else {
+        data
+    };
+    core::slice::from_raw_parts(data, len)
+}
+
+pub unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {
+    let data = if data.is_null() {
+        core::ptr::NonNull::dangling().as_ptr()
+    } else {
+        data
+    };
+    core::slice::from_raw_parts_mut(data, len)
+}

--- a/crates/schnorrkel/Cargo.lock
+++ b/crates/schnorrkel/Cargo.lock
@@ -166,6 +166,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp"
+version = "0.0.1"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +681,7 @@ version = "0.2.0"
 dependencies = [
  "bitvec",
  "build-helper",
+ "cpp",
  "ed25519-dalek",
  "hex-literal",
  "itertools",

--- a/crates/schnorrkel/Cargo.toml
+++ b/crates/schnorrkel/Cargo.toml
@@ -10,6 +10,7 @@ name = "schnorrkel_crust"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
+cpp = { path = "../cpp" }
 schnorrkel = { version="0.9.1", features = ["preaudit_deprecated"] }
 ed25519-dalek = { version="1.0.0" }
 rand_chacha = "0.3.1"

--- a/crates/schnorrkel/src/ed25519.rs
+++ b/crates/schnorrkel/src/ed25519.rs
@@ -1,12 +1,14 @@
+use std::os::raw::c_ulong;
+use std::{ptr, slice};
+
 use ed25519_dalek::ed25519::signature::Signature;
 use ed25519_dalek::{
     Keypair, PublicKey, SecretKey, Signer, Verifier, KEYPAIR_LENGTH, PUBLIC_KEY_LENGTH,
     SIGNATURE_LENGTH,
 };
-use std::os::raw::c_ulong;
-use std::{ptr, slice};
 
 use crate::constants::ED25519_SEED_LENGTH;
+use crate::{align_slice_ptr};
 
 /// Status code of a function call
 #[repr(C)]
@@ -63,7 +65,7 @@ pub unsafe extern "C" fn ed25519_sign(
     if keypair_ptr.is_null() || message_ptr.is_null() {
         return Ed25519Result::NullArgument;
     }
-    let message = slice::from_raw_parts(message_ptr, message_size as usize);
+    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_size as usize);
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, KEYPAIR_LENGTH);
     let keypair = match Keypair::from_bytes(keypair_bytes) {
         Ok(kp) => kp,
@@ -100,7 +102,7 @@ pub unsafe extern "C" fn ed25519_verify(
     }
     let public_key_bytes = slice::from_raw_parts(public_key_ptr, PUBLIC_KEY_LENGTH);
     let signature_bytes = slice::from_raw_parts(signature_ptr, SIGNATURE_LENGTH);
-    let message_bytes = slice::from_raw_parts(message_ptr, message_size as usize);
+    let message_bytes = slice::from_raw_parts(align_slice_ptr(message_ptr), message_size as usize);
     let public_key = match PublicKey::from_bytes(public_key_bytes) {
         Ok(pk) => pk,
         Err(_) => return Ed25519Result::PublicKeyFromBytesFailed,

--- a/crates/schnorrkel/src/ed25519.rs
+++ b/crates/schnorrkel/src/ed25519.rs
@@ -8,7 +8,6 @@ use ed25519_dalek::{
 };
 
 use crate::constants::ED25519_SEED_LENGTH;
-use crate::{align_slice_ptr};
 
 /// Status code of a function call
 #[repr(C)]
@@ -65,7 +64,7 @@ pub unsafe extern "C" fn ed25519_sign(
     if keypair_ptr.is_null() || message_ptr.is_null() {
         return Ed25519Result::NullArgument;
     }
-    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_size as usize);
+    let message = cpp::from_raw_parts(message_ptr, message_size as usize);
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, KEYPAIR_LENGTH);
     let keypair = match Keypair::from_bytes(keypair_bytes) {
         Ok(kp) => kp,
@@ -102,7 +101,7 @@ pub unsafe extern "C" fn ed25519_verify(
     }
     let public_key_bytes = slice::from_raw_parts(public_key_ptr, PUBLIC_KEY_LENGTH);
     let signature_bytes = slice::from_raw_parts(signature_ptr, SIGNATURE_LENGTH);
-    let message_bytes = slice::from_raw_parts(align_slice_ptr(message_ptr), message_size as usize);
+    let message_bytes = cpp::from_raw_parts(message_ptr, message_size as usize);
     let public_key = match PublicKey::from_bytes(public_key_bytes) {
         Ok(pk) => pk,
         Err(_) => return Ed25519Result::PublicKeyFromBytesFailed,

--- a/crates/schnorrkel/src/lib.rs
+++ b/crates/schnorrkel/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2024 Quadrivium via https://github.com/qdrvm/kagome-crates
 // Copyright 2019 Soramitsu via https://github.com/Warchant/sr25519-crust
 // Copyright 2019 Paritytech via https://github.com/paritytech/schnorrkel-js/
 // Copyright 2019 @polkadot/wasm-schnorrkel authors & contributors
@@ -16,6 +17,16 @@
 //!
 //! Glue code to generate C headers for sr25519 and ed25519 rust implementations
 //!
+
+// Calling code may pass a null pointer for empty slices, but Rust expects an aligned pointer
+pub(crate) fn align_slice_ptr<T>(ptr: *const T) -> *const T {
+    if ptr == core::ptr::null() {
+        core::ptr::NonNull::<T>::dangling().as_ptr() as *const _
+    } else {
+        ptr
+    }
+}
+
 /// Bitfield impls
 pub mod bitfield;
 

--- a/crates/schnorrkel/src/lib.rs
+++ b/crates/schnorrkel/src/lib.rs
@@ -18,15 +18,6 @@
 //! Glue code to generate C headers for sr25519 and ed25519 rust implementations
 //!
 
-// Calling code may pass a null pointer for empty slices, but Rust expects an aligned pointer
-pub(crate) fn align_slice_ptr<T>(ptr: *const T) -> *const T {
-    if ptr == core::ptr::null() {
-        core::ptr::NonNull::<T>::dangling().as_ptr() as *const _
-    } else {
-        ptr
-    }
-}
-
 /// Bitfield impls
 pub mod bitfield;
 

--- a/crates/schnorrkel/src/sr25519.rs
+++ b/crates/schnorrkel/src/sr25519.rs
@@ -3,7 +3,6 @@ use std::os::raw::c_ulong;
 use std::ptr;
 use std::slice;
 
-use crate::{align_slice_ptr};
 pub use merlin::Transcript;
 use parity_scale_codec::Encode;
 use rand::{seq::SliceRandom, SeedableRng};
@@ -385,7 +384,7 @@ pub unsafe extern "C" fn sr25519_sign(
 ) {
     let public = slice::from_raw_parts(public_ptr, SR25519_PUBLIC_SIZE as usize);
     let secret = slice::from_raw_parts(secret_ptr, SR25519_SECRET_SIZE as usize);
-    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
+    let message = cpp::from_raw_parts(message_ptr, message_length as usize);
 
     let sig = create_secret(secret).sign_simple(SIGNING_CTX, message, &create_public(public));
 
@@ -414,7 +413,7 @@ pub unsafe extern "C" fn sr25519_verify_deprecated(
 ) -> bool {
     let public = slice::from_raw_parts(public_ptr, SR25519_PUBLIC_SIZE as usize);
     let signature = slice::from_raw_parts(signature_ptr, SR25519_SIGNATURE_SIZE as usize);
-    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
+    let message = cpp::from_raw_parts(message_ptr, message_length as usize);
 
     create_public(public)
         .verify_simple_preaudit_deprecated(SIGNING_CTX, message, &signature)
@@ -439,7 +438,7 @@ pub unsafe extern "C" fn sr25519_verify(
 ) -> bool {
     let public = slice::from_raw_parts(public_ptr, SR25519_PUBLIC_SIZE as usize);
     let signature = slice::from_raw_parts(signature_ptr, SR25519_SIGNATURE_SIZE as usize);
-    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
+    let message = cpp::from_raw_parts(message_ptr, message_length as usize);
     let signature = match Signature::from_bytes(signature) {
         Ok(signature) => signature,
         Err(_) => return false,
@@ -503,7 +502,7 @@ pub unsafe extern "C" fn sr25519_vrf_sign_if_less(
 ) -> VrfResult {
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, SR25519_KEYPAIR_SIZE as usize);
     let keypair = create_from_pair(keypair_bytes);
-    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
+    let message = cpp::from_raw_parts(message_ptr, message_length as usize);
 
     let limit = slice::from_raw_parts(limit_ptr, SR25519_VRF_THRESHOLD_SIZE as usize);
     let mut limit_arr: [u8; SR25519_VRF_THRESHOLD_SIZE as usize] = Default::default();
@@ -561,7 +560,7 @@ pub unsafe extern "C" fn sr25519_vrf_verify(
         public_key_ptr,
         SR25519_PUBLIC_SIZE as usize,
     ));
-    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
+    let message = cpp::from_raw_parts(message_ptr, message_length as usize);
     let ctx = signing_context(SIGNING_CTX).bytes(message);
     let given_out = return_if_err!(VRFOutput::from_bytes(slice::from_raw_parts(
         output_ptr,
@@ -810,7 +809,7 @@ pub unsafe extern "C" fn sr25519_relay_vrf_modulo_assignments_cert_v2(
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, SR25519_KEYPAIR_SIZE as usize);
     let assignments_key = create_from_pair(keypair_bytes);
 
-    let leaving_cores = slice::from_raw_parts(align_slice_ptr(leaving_cores_ptr), leaving_cores_num as usize);
+    let leaving_cores = cpp::from_raw_parts(leaving_cores_ptr, leaving_cores_num as usize);
 
     let relay_vrf_story =
         std::mem::transmute::<*const RelayVRFStory, &RelayVRFStory>(relay_vrf_story);
@@ -867,7 +866,7 @@ pub unsafe extern "C" fn sr25519_relay_vrf_modulo_assignments_cert_v2(
 #[allow(unused_attributes)]
 #[no_mangle]
 pub unsafe extern "C" fn sr25519_clear_assigned_cores_v2(cores_out: *mut u32, cores_out_sz: u64) {
-    let _ = Box::<[u32]>::from(std::slice::from_raw_parts(align_slice_ptr(cores_out), cores_out_sz as usize));
+    let _ = Box::<[u32]>::from(cpp::from_raw_parts(cores_out, cores_out_sz as usize));
 }
 
 /// Computes output and proof for valid VRF assignment certificate.
@@ -900,7 +899,7 @@ pub unsafe extern "C" fn sr25519_relay_vrf_modulo_assignments_cert(
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, SR25519_KEYPAIR_SIZE as usize);
     let assignments_key = create_from_pair(keypair_bytes);
 
-    let leaving_cores = slice::from_raw_parts(align_slice_ptr(leaving_cores_ptr), leaving_cores_num as usize);
+    let leaving_cores = cpp::from_raw_parts(leaving_cores_ptr, leaving_cores_num as usize);
 
     let mut core = u32::default();
     let relay_vrf_story =

--- a/crates/schnorrkel/src/sr25519.rs
+++ b/crates/schnorrkel/src/sr25519.rs
@@ -3,7 +3,7 @@ use std::os::raw::c_ulong;
 use std::ptr;
 use std::slice;
 
-use itertools::Itertools;
+use crate::{align_slice_ptr};
 pub use merlin::Transcript;
 use parity_scale_codec::Encode;
 use rand::{seq::SliceRandom, SeedableRng};
@@ -385,7 +385,7 @@ pub unsafe extern "C" fn sr25519_sign(
 ) {
     let public = slice::from_raw_parts(public_ptr, SR25519_PUBLIC_SIZE as usize);
     let secret = slice::from_raw_parts(secret_ptr, SR25519_SECRET_SIZE as usize);
-    let message = slice::from_raw_parts(message_ptr, message_length as usize);
+    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
 
     let sig = create_secret(secret).sign_simple(SIGNING_CTX, message, &create_public(public));
 
@@ -414,7 +414,7 @@ pub unsafe extern "C" fn sr25519_verify_deprecated(
 ) -> bool {
     let public = slice::from_raw_parts(public_ptr, SR25519_PUBLIC_SIZE as usize);
     let signature = slice::from_raw_parts(signature_ptr, SR25519_SIGNATURE_SIZE as usize);
-    let message = slice::from_raw_parts(message_ptr, message_length as usize);
+    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
 
     create_public(public)
         .verify_simple_preaudit_deprecated(SIGNING_CTX, message, &signature)
@@ -439,7 +439,7 @@ pub unsafe extern "C" fn sr25519_verify(
 ) -> bool {
     let public = slice::from_raw_parts(public_ptr, SR25519_PUBLIC_SIZE as usize);
     let signature = slice::from_raw_parts(signature_ptr, SR25519_SIGNATURE_SIZE as usize);
-    let message = slice::from_raw_parts(message_ptr, message_length as usize);
+    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
     let signature = match Signature::from_bytes(signature) {
         Ok(signature) => signature,
         Err(_) => return false,
@@ -503,7 +503,7 @@ pub unsafe extern "C" fn sr25519_vrf_sign_if_less(
 ) -> VrfResult {
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, SR25519_KEYPAIR_SIZE as usize);
     let keypair = create_from_pair(keypair_bytes);
-    let message = slice::from_raw_parts(message_ptr, message_length as usize);
+    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
 
     let limit = slice::from_raw_parts(limit_ptr, SR25519_VRF_THRESHOLD_SIZE as usize);
     let mut limit_arr: [u8; SR25519_VRF_THRESHOLD_SIZE as usize] = Default::default();
@@ -561,7 +561,7 @@ pub unsafe extern "C" fn sr25519_vrf_verify(
         public_key_ptr,
         SR25519_PUBLIC_SIZE as usize,
     ));
-    let message = slice::from_raw_parts(message_ptr, message_length as usize);
+    let message = slice::from_raw_parts(align_slice_ptr(message_ptr), message_length as usize);
     let ctx = signing_context(SIGNING_CTX).bytes(message);
     let given_out = return_if_err!(VRFOutput::from_bytes(slice::from_raw_parts(
         output_ptr,
@@ -810,7 +810,7 @@ pub unsafe extern "C" fn sr25519_relay_vrf_modulo_assignments_cert_v2(
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, SR25519_KEYPAIR_SIZE as usize);
     let assignments_key = create_from_pair(keypair_bytes);
 
-    let leaving_cores = slice::from_raw_parts(leaving_cores_ptr, leaving_cores_num as usize);
+    let leaving_cores = slice::from_raw_parts(align_slice_ptr(leaving_cores_ptr), leaving_cores_num as usize);
 
     let relay_vrf_story =
         std::mem::transmute::<*const RelayVRFStory, &RelayVRFStory>(relay_vrf_story);
@@ -866,11 +866,8 @@ pub unsafe extern "C" fn sr25519_relay_vrf_modulo_assignments_cert_v2(
 /// @param cores_cap - leaving cores capacity
 #[allow(unused_attributes)]
 #[no_mangle]
-pub unsafe extern "C" fn sr25519_clear_assigned_cores_v2(
-    cores_out: *mut u32,
-    cores_out_sz: u64,
-) {
-    let _ = Box::<[u32]>::from(std::slice::from_raw_parts(cores_out, cores_out_sz as usize));
+pub unsafe extern "C" fn sr25519_clear_assigned_cores_v2(cores_out: *mut u32, cores_out_sz: u64) {
+    let _ = Box::<[u32]>::from(std::slice::from_raw_parts(align_slice_ptr(cores_out), cores_out_sz as usize));
 }
 
 /// Computes output and proof for valid VRF assignment certificate.
@@ -903,7 +900,7 @@ pub unsafe extern "C" fn sr25519_relay_vrf_modulo_assignments_cert(
     let keypair_bytes = slice::from_raw_parts(keypair_ptr, SR25519_KEYPAIR_SIZE as usize);
     let assignments_key = create_from_pair(keypair_bytes);
 
-    let leaving_cores = slice::from_raw_parts(leaving_cores_ptr, leaving_cores_num as usize);
+    let leaving_cores = slice::from_raw_parts(align_slice_ptr(leaving_cores_ptr), leaving_cores_num as usize);
 
     let mut core = u32::default();
     let relay_vrf_story =


### PR DESCRIPTION
Calling code may reasonably pass a null pointer for an empty slice, but Rust always expects the slice pointer to be aligned and non null. Hence additional processing is required.